### PR TITLE
Add a high-level method to assemble single-cell data with AnnData

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     'pandas',
     'numpy',
     'anndata',
-    'scanpy @ file:///home/guillaume/Projets/scanpy',
+    'scanpy >= 1.12.0rc1',
     'typing'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     'pandas',
     'numpy',
     'anndata',
-    'scanpy',
+    'scanpy @ file:///home/guillaume/Projets/scanpy',
     'typing'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     'pandas',
     'numpy',
     'anndata',
+    'scanpy',
     'typing'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "a Python Wrapper for the Gemma API"
 keywords = ["gemma", "bioinformatics"]
 readme = "README.rst"
 version = "2.0.4"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     'certifi >= 14.05.14',
     'six >= 1.10',

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -70,6 +70,19 @@ def test_auth(monkeypatch):
         monkeypatch.setitem(os.environ, 'GEMMA_PASSWORD_CMD', '')
         gemmapy.GemmaPy()
 
+def test_get_single_cell_data():
+    # TODO: use a publicly available dataset
+    client = gemmapy.GemmaPy()
+    ad = client.get_single_cell_dataset_object('GSE227313', download_dir='.')
+    print(ad)
+
+def test_get_genes():
+    assert len(api.get_genes('BRCA1')) > 0
+    assert len(api.get_genes(['BRCA1'])) > 0
+    assert len(api.get_genes(672)) > 0
+    assert len(api.get_genes([672])) > 0
+    assert len(api.get_genes([672, 'BRCA1'])) > 0
+
 def test_get_result_sets():
     res = api.get_result_sets([200])
     


### PR DESCRIPTION
TODO:

- [x] concatenate multiple datasets
- [ ] create a multi-index (dataset_id, sample_id, cell_id), the dataset-level can be omitted if a single dataset is requested
- [ ] include factors, sample characteristics and cell-level characteristics
- [ ] deal with multiple platforms (I think we could use the design element ID for that, or a multi-level index)
- [ ] generalize the concept of `download_dir` and implement some form of invalidation, I think that the Last-Modified is exposed by the backend and there might even be Cache-Control headers we could leverage there.

Depends on #38 because I needed authentication for the test dataset. The final PR will use a public dataset.