### PR TITLE
test: check annotations DataFrame columns by name, not strict shape[1] == 5

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -104,7 +104,14 @@ def test_search_annotations():
 def test_get_dataset_annotations():
     res = api.get_dataset_annotations(1)
     assert type(res) is pd.core.frame.DataFrame
-    assert res.shape[1] == 5
+    # Expected columns. evidence_code was added in fb7afb8 ("add evidence
+    # code to annotation processing") but the test's bare shape[1] == 5
+    # assertion wasn't updated, so it failed once gemma-rest started
+    # emitting evidenceCode. Check by name instead of count so future
+    # additive fields don't break this test the same way.
+    expected = {"class_name", "class_URI", "term_name", "term_URI",
+                "object_class", "evidence_code"}
+    assert expected.issubset(set(res.columns))
 
 def test_get_dataset_differential_expression_analyses():
     res = api.get_dataset_differential_expression_analyses(200)


### PR DESCRIPTION
## Summary

- `test_get_dataset_annotations` has been one column behind since gemmapy commit `fb7afb8` ("add evidence code to annotation processing") added `evidence_code` to the DataFrame projection without updating the test's `shape[1] == 5` assertion.
- Replace the bare column-count check with an expected-column-name subset assertion. The intent of the test (ensure the expected columns are present) is preserved; the brittle "exactly 5 columns" rigidity is removed.
- Drives compatibility forward — server-side additive fields on `/datasets/{id}/annotations` will not break this test the next time something is added.

## Why this matters

While auditing v1/v2 API compatibility between the current `gemma-rest` (`2.0.0-alpha-SNAPSHOT`) and gemmapy / gemma.R, this was the only gemmapy test that failed against a fresh local container. 10/11 `test_basic.py` tests pass; this one fails purely because the assertion is rigid against an additive change that already landed on both sides.

Server-side wire shape is unchanged from gemmapy's perspective. No new client-visible field; this is purely a test-fixture update.

## Test plan

- [x] Run the test against a local Gemma container `http://localhost:8080/rest/v2` — passes.
- [ ] Wait for CI to pick it up against staging / prod.
